### PR TITLE
[Reviewer: Alex] Make python-common more generic

### DIFF
--- a/metaswitch/common/logging_config.py
+++ b/metaswitch/common/logging_config.py
@@ -70,7 +70,7 @@ class ClearwaterLogHandler(BaseRotatingHandler):
         self.next_file_change = (int(currentTime / 3600) * 3600) + 3600
 
 
-def configure_logging(task_id, log_level, log_dir, log_prefix, task_id=None):
+def configure_logging(log_level, log_dir, log_prefix, task_id=None):
     if task_id:
         log_prefix += "-{}".format(task_id)
 

--- a/metaswitch/common/logging_config.py
+++ b/metaswitch/common/logging_config.py
@@ -70,18 +70,23 @@ class ClearwaterLogHandler(BaseRotatingHandler):
         self.next_file_change = (int(currentTime / 3600) * 3600) + 3600
 
 
-def configure_logging(task_id, settings):
+def configure_logging(task_id, log_level, log_dir, log_prefix, task_id=None):
+    if task_id:
+        log_prefix += "-{}".format(task_id)
+
     # Configure the root logger to accept all messages. We control the log level
     # through the handler attached to it (see below).
     root_log = logging.getLogger()
     root_log.setLevel(logging.DEBUG)
     for h in root_log.handlers:
         root_log.removeHandler(h)
+
+
     fmt = logging.Formatter('%(asctime)s.%(msecs)03d UTC %(levelname)s %(filename)s:%(lineno)d: %(message)s', "%d-%m-%Y %H:%M:%S")
     fmt.converter = time.gmtime
-    handler = ClearwaterLogHandler(settings.LOGS_DIR, task_id)
+    handler = ClearwaterLogHandler(log_dir, log_prefix)
     handler.setFormatter(fmt)
-    handler.setLevel(settings.LOG_LEVEL)
+    handler.setLevel(log_level)
     root_log.addHandler(handler)
     
     def exception_logging_handler(type, value, tb):

--- a/metaswitch/common/phonenumber_utils.py
+++ b/metaswitch/common/phonenumber_utils.py
@@ -1,5 +1,3 @@
-# @file setup.py
-#
 # Project Clearwater - IMS in the Cloud
 # Copyright (C) 2013  Metaswitch Networks Ltd
 #
@@ -32,26 +30,15 @@
 # under which the OpenSSL Project distributes the OpenSSL toolkit software,
 # as those licenses appear in the file LICENSE-OPENSSL.
 
-import logging
-import sys
+import phonenumbers
 
-from setuptools import setup, find_packages
-from logging import StreamHandler
+def format_phone_number(number):
+    try:
+        # TODO support non-US
+        numobj = phonenumbers.parse(number, "US")
+        number = phonenumbers.format_number(numobj,
+                                            phonenumbers.PhoneNumberFormat.NATIONAL)
+    except Exception:
+        return number
+    return number
 
-_log = logging.getLogger("common")
-_log.setLevel(logging.DEBUG)
-_handler = StreamHandler(sys.stderr)
-_handler.setLevel(logging.DEBUG)
-_log.addHandler(_handler)
-
-_log.info("Packages %s", find_packages('.'))
-
-setup(
-    name='metaswitchcommon',
-    version='0.1',
-    packages=find_packages('.'),
-    package_dir={'':'.'},
-    test_suite='metaswitch.common.test',
-    install_requires=["py-bcrypt"],
-    tests_require["Mock"]
-    )

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,6 @@ setup(
     packages=find_packages('.'),
     package_dir={'':'.'},
     test_suite='metaswitch.common.test',
-    install_requires=["py-bcrypt"],
-    tests_require["Mock"]
+    install_requires=["py-bcrypt", "pycrypto"],
+    tests_require=["Mock"]
     )


### PR DESCRIPTION
python-common is quite closely tied to Ellis and Crest. This PR makes it less so.

Specifically, I've:

* dropped the setup.py dependency on tornado
* split Tornado- and libphonenumber-related utilities out, so that it's possible to import 'utils' without having those
* removed configure_logging's expectation that we have a settings.py module, so it can be set up from command-line arguments

The resulting model is a bit closer to cpp-common - where things like diameterstack.cpp expect you to have freeDiameter, but it's the parent application's job to build and link freeDiameter. Likewise, tornado_utils.py depends on Tornado, but it's Crest's/Ellis' responsibility to install Tornado before using tornado_utils.