### PR TITLE
[Reviewer: Ellie] Add Python communication monitor

### DIFF
--- a/metaswitch/common/alarms.py
+++ b/metaswitch/common/alarms.py
@@ -1,0 +1,59 @@
+# @file alarms.py
+#
+# Project Clearwater - IMS in the Cloud
+# Copyright (C) 2015 Metaswitch Networks Ltd
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version, along with the "Special Exception" for use of
+# the program along with SSL, set forth below. This program is distributed
+# in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details. You should have received a copy of the GNU General Public
+# License along with this program.  If not, see
+# <http://www.gnu.org/licenses/>.
+#
+# The author can be reached by email at clearwater@metaswitch.com or by
+# post at Metaswitch Networks Ltd, 100 Church St, Enfield EN2 6BQ, UK
+#
+# Special Exception
+# Metaswitch Networks Ltd  grants you permission to copy, modify,
+# propagate, and distribute a work formed by combining OpenSSL with The
+# Software, or a work derivative of such a combination, even if such
+# copying, modification, propagation, or distribution would otherwise
+# violate the terms of the GPL. You must comply with the GPL in all
+# respects for all of the code used other than OpenSSL.
+# "OpenSSL" means OpenSSL toolkit software distributed by the OpenSSL
+# Project and licensed under the OpenSSL Licenses, or a work based on such
+# software and licensed under the OpenSSL Licenses.
+# "OpenSSL Licenses" means the OpenSSL License and Original SSLeay License
+# under which the OpenSSL Project distributes the OpenSSL toolkit software,
+# as those licenses appear in the file LICENSE-OPENSSL.
+
+
+# This module provides a method for transporting alarm requests to a net-
+# snmp alarm sub-agent for further handling. If the agent is unavailable,
+# the request will timeout after 2 seconds and be dropped.
+
+
+import logging
+from threading import Thread, Condition
+import imp
+
+_log = logging.getLogger(__name__)
+
+sendrequest = None
+
+try:
+    file, pathname, description = imp.find_module("alarms", ["/usr/share/clearwater/bin"])
+    mod = imp.load_module("alarms", file, pathname, description)
+    sendrequest = mod.sendrequest
+except ImportError:
+    _log.error("Could not import /usr/share/clearwater/bin/alarms.py, alarms will not be sent")
+
+
+def issue_alarm(identifier):
+    if sendrequest:
+        sendrequest(["issue-alarm", "cluster-manager", identifier])

--- a/metaswitch/common/alarms.py
+++ b/metaswitch/common/alarms.py
@@ -54,6 +54,6 @@ except ImportError:
     _log.error("Could not import /usr/share/clearwater/bin/alarms.py, alarms will not be sent")
 
 
-def issue_alarm(identifier):
+def issue_alarm(process, identifier):
     if sendrequest:
-        sendrequest(["issue-alarm", "cluster-manager", identifier])
+        sendrequest(["issue-alarm", process, identifier])

--- a/metaswitch/common/comm_monitor.py
+++ b/metaswitch/common/comm_monitor.py
@@ -1,0 +1,82 @@
+# @file comm_monitor.py
+#
+# Project Clearwater - IMS in the Cloud
+# Copyright (C) 2015 Metaswitch Networks Ltd
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version, along with the "Special Exception" for use of
+# the program along with SSL, set forth below. This program is distributed
+# in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details. You should have received a copy of the GNU General Public
+# License along with this program.  If not, see
+# <http://www.gnu.org/licenses/>.
+#
+# The author can be reached by email at clearwater@metaswitch.com or by
+# post at Metaswitch Networks Ltd, 100 Church St, Enfield EN2 6BQ, UK
+#
+# Special Exception
+# Metaswitch Networks Ltd  grants you permission to copy, modify,
+# propagate, and distribute a work formed by combining OpenSSL with The
+# Software, or a work derivative of such a combination, even if such
+# copying, modification, propagation, or distribution would otherwise
+# violate the terms of the GPL. You must comply with the GPL in all
+# respects for all of the code used other than OpenSSL.
+# "OpenSSL" means OpenSSL toolkit software distributed by the OpenSSL
+# Project and licensed under the OpenSSL Licenses, or a work based on such
+# software and licensed under the OpenSSL Licenses.
+# "OpenSSL Licenses" means the OpenSSL License and Original SSLeay License
+# under which the OpenSSL Project distributes the OpenSSL toolkit software,
+# as those licenses appear in the file LICENSE-OPENSSL.
+
+import logging
+from threading import Lock
+from alarms import issue_alarm
+from monotonic_time import monotonic_time
+
+_log = logging.getLogger(__name__)
+
+class CommunicationMonitor(object):
+    def __init__(self, raise_identifier, clear_identifier):
+        self._raise_identifier = raise_identifier
+        self._clear_identifier = clear_identifier
+        self.succeeded = 0
+        self.failed = 0
+        self.alarmed = False
+        self.mutex = Lock()
+        self._next_check = 0
+
+    def set_alarm(self):
+        self.alarmed = True
+        issue_alarm(self._raise_identifier)
+
+    def clear_alarm(self):
+        self.alarmed = False
+        issue_alarm(self._clear_identifier)
+
+    def update_alarm_state(self):
+        now = monotonic_time()
+        with self.mutex:
+            if (now > self._next_check):
+                if not self.alarmed:
+                    if self.succeeded == 0 and self.failed > 0:
+                        self.set_alarm()
+                    self._next_check = now + 30
+                else:
+                    if self.succeeded > 0:
+                        self.clear_alarm()
+                    self._next_check = now + 15
+                self.succeeded = self.failed = 0
+
+    def inform_success(self):
+        self.succeeded += 1
+        self.update_alarm_state()
+
+    def inform_failure(self):
+        self.failed += 1
+        self.update_alarm_state()
+
+

--- a/metaswitch/common/comm_monitor.py
+++ b/metaswitch/common/comm_monitor.py
@@ -40,7 +40,8 @@ from monotonic_time import monotonic_time
 _log = logging.getLogger(__name__)
 
 class CommunicationMonitor(object):
-    def __init__(self, raise_identifier, clear_identifier):
+    def __init__(self, process, raise_identifier, clear_identifier):
+        self._process = process
         self._raise_identifier = raise_identifier
         self._clear_identifier = clear_identifier
         self.succeeded = 0
@@ -51,11 +52,11 @@ class CommunicationMonitor(object):
 
     def set_alarm(self):
         self.alarmed = True
-        issue_alarm(self._raise_identifier)
+        issue_alarm(self._process, self._raise_identifier)
 
     def clear_alarm(self):
         self.alarmed = False
-        issue_alarm(self._clear_identifier)
+        issue_alarm(self._process, self._clear_identifier)
 
     def update_alarm_state(self):
         now = monotonic_time()

--- a/metaswitch/common/monotonic_time.py
+++ b/metaswitch/common/monotonic_time.py
@@ -1,0 +1,54 @@
+# @file monotonic_time.py
+#
+# Project Clearwater - IMS in the Cloud
+# Copyright (C) 2014  Metaswitch Networks Ltd
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version, along with the "Special Exception" for use of
+# the program along with SSL, set forth below. This program is distributed
+# in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details. You should have received a copy of the GNU General Public
+# License along with this program.  If not, see
+# <http://www.gnu.org/licenses/>.
+#
+# The author can be reached by email at clearwater@metaswitch.com or by
+# post at Metaswitch Networks Ltd, 100 Church St, Enfield EN2 6BQ, UK
+#
+# Special Exception
+# Metaswitch Networks Ltd  grants you permission to copy, modify,
+# propagate, and distribute a work formed by combining OpenSSL with The
+# Software, or a work derivative of such a combination, even if such
+# copying, modification, propagation, or distribution would otherwise
+# violate the terms of the GPL. You must comply with the GPL in all
+# respects for all of the code used other than OpenSSL.
+# "OpenSSL" means OpenSSL toolkit software distributed by the OpenSSL
+# Project and licensed under the OpenSSL Licenses, or a work based on such
+# software and licensed under the OpenSSL Licenses.
+# "OpenSSL Licenses" means the OpenSSL License and Original SSLeay License
+# under which the OpenSSL Project distributes the OpenSSL toolkit software,
+# as those licenses appear in the file LICENSE-OPENSSL.
+
+import ctypes, os
+
+CLOCK_MONOTONIC_RAW = 4 # see <linux/time.h>
+
+class timespec(ctypes.Structure):
+    _fields_ = [
+        ('tv_sec', ctypes.c_long),
+        ('tv_nsec', ctypes.c_long)
+    ]
+
+librt = ctypes.CDLL('librt.so.1', use_errno=True)
+clock_gettime = librt.clock_gettime
+clock_gettime.argtypes = [ctypes.c_int, ctypes.POINTER(timespec)]
+
+def monotonic_time():
+    t = timespec()
+    if clock_gettime(CLOCK_MONOTONIC_RAW , ctypes.pointer(t)) != 0:
+        errno_ = ctypes.get_errno()
+        raise OSError(errno_, os.strerror(errno_))
+    return t.tv_sec + t.tv_nsec * 1e-9

--- a/metaswitch/common/test/comm_monitor.py
+++ b/metaswitch/common/test/comm_monitor.py
@@ -1,0 +1,60 @@
+# @file throttler.py
+#
+# Project Clearwater - IMS in the Cloud
+# Copyright (C) 2013  Metaswitch Networks Ltd
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version, along with the "Special Exception" for use of
+# the program along with SSL, set forth below. This program is distributed
+# in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details. You should have received a copy of the GNU General Public
+# License along with this program.  If not, see
+# <http://www.gnu.org/licenses/>.
+#
+# The author can be reached by email at clearwater@metaswitch.com or by
+# post at Metaswitch Networks Ltd, 100 Church St, Enfield EN2 6BQ, UK
+#
+# Special Exception
+# Metaswitch Networks Ltd  grants you permission to copy, modify,
+# propagate, and distribute a work formed by combining OpenSSL with The
+# Software, or a work derivative of such a combination, even if such
+# copying, modification, propagation, or distribution would otherwise
+# violate the terms of the GPL. You must comply with the GPL in all
+# respects for all of the code used other than OpenSSL.
+# "OpenSSL" means OpenSSL toolkit software distributed by the OpenSSL
+# Project and licensed under the OpenSSL Licenses, or a work based on such
+# software and licensed under the OpenSSL Licenses.
+# "OpenSSL Licenses" means the OpenSSL License and Original SSLeay License
+# under which the OpenSSL Project distributes the OpenSSL toolkit software,
+# as those licenses appear in the file LICENSE-OPENSSL.
+
+
+import unittest
+import mock
+
+from metaswitch.common.comm_monitor import CommunicationMonitor
+
+class CMTestCase(unittest.TestCase):
+    @mock.patch("metaswitch.common.comm_monitor.issue_alarm")
+    @mock.patch("metaswitch.common.comm_monitor.monotonic_time")
+    def test_simple(self, mock_time, mock_alarm):
+        """Simple test of basic behaviour."""
+        cm = CommunicationMonitor("raise", "clear")
+
+        # Move time forwards and report a failure. We should raise an alarm.
+        mock_time.return_value = 1000
+        cm.inform_failure()
+        mock_alarm.assert_called_with("raise")
+
+        # Move time forwards and report a success. We should clear that alarm.
+        mock_time.return_value = 3000
+        cm.inform_success()
+        mock_alarm.assert_called_with("clear")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/metaswitch/common/test/comm_monitor.py
+++ b/metaswitch/common/test/comm_monitor.py
@@ -43,17 +43,17 @@ class CMTestCase(unittest.TestCase):
     @mock.patch("metaswitch.common.comm_monitor.monotonic_time")
     def test_simple(self, mock_time, mock_alarm):
         """Simple test of basic behaviour."""
-        cm = CommunicationMonitor("raise", "clear")
+        cm = CommunicationMonitor("ut", "raise", "clear")
 
         # Move time forwards and report a failure. We should raise an alarm.
         mock_time.return_value = 1000
         cm.inform_failure()
-        mock_alarm.assert_called_with("raise")
+        mock_alarm.assert_called_with("ut", "raise")
 
         # Move time forwards and report a success. We should clear that alarm.
         mock_time.return_value = 3000
         cm.inform_success()
-        mock_alarm.assert_called_with("clear")
+        mock_alarm.assert_called_with("ut", "clear")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This also pulls in alarms code from clearwater-etcd and CLOCK_MONOTONIC code from Crest.