### PR TITLE
Reviewer Matt - Use C compiler to compile C code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 ENV_DIR := $(shell pwd)/_env
 PYTHON_BIN := $(shell which python)
 
-COMPILER_FLAGS := LIBRARY_PATH=. CC="g++ -Icpp-common/include"
+COMPILER_FLAGS := LIBRARY_PATH=. CC="${CC} -Icpp-common/include"
 
 # The build has been seen to fail on Mac OSX when trying to build on i386. Enable this to build for x86_64 only
 X86_64_ONLY=0


### PR DESCRIPTION
@rkd-msw recently (d0a33f97) changed the `CC` complier used to build python packages (so he could provide `cpp-common`'s `include` directory) but as a side effect, he switched us to compiling the code with `g++` rather than `gcc`.

This PR changes us back so we use the normal `${CC}` compiler and just add the extra flag.  This is the root cause of the current Ellis build failure on Jenkins.  Tested on the Jenkins server to ensure this resolves the issue.