### PR TITLE
[Reviewer Ellie] Build error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,13 +73,12 @@ clean: envclean pyclean
 pyclean:
 	find . -name \*.pyc -exec rm -f {} \;
 	rm -rf *.egg-info dist
-	rm -rf $(EGG_DIR)
 	rm -f .coverage
 	rm -rf htmlcov/
 
 .PHONY: envclean
 envclean:
-	rm -rf bin eggs develop-eggs parts .installed.cfg bootstrap.py .downloads .buildout_downloads
+	rm -rf bin .eggs .develop-eggs parts .installed.cfg bootstrap.py .downloads .buildout_downloads
 	rm -rf distribute-*.tar.gz
 	rm -rf $(ENV_DIR)
 	rm metaswitch/common/_cffi.so *.o libclearwaterutils.a

--- a/Makefile
+++ b/Makefile
@@ -56,13 +56,13 @@ build_common_egg: $(ENV_DIR)/bin/python setup.py libclearwaterutils.a
 ${ENV_DIR}/.eggs_installed : $(ENV_DIR)/bin/python setup.py $(shell find metaswitch -type f -not -name "*.pyc") libclearwaterutils.a
 	# Generate .egg files for python-common
 	$(COMPILER_FLAGS) ${ENV_DIR}/bin/python setup.py bdist_egg -d .eggs
-	
+
 	# Download the egg files they depend upon
 	${ENV_DIR}/bin/easy_install -zmaxd .eggs/ .eggs/*.egg
-	
+
 	# Install the downloaded egg files
 	${ENV_DIR}/bin/easy_install --allow-hosts=None -f .eggs/ .eggs/*.egg
-	
+
 	# Touch the sentinel file
 	touch $@
 
@@ -73,6 +73,7 @@ clean: envclean pyclean
 pyclean:
 	find . -name \*.pyc -exec rm -f {} \;
 	rm -rf *.egg-info dist
+	rm -rf $(EGG_DIR)
 	rm -f .coverage
 	rm -rf htmlcov/
 


### PR DESCRIPTION
I've fixed up the Makefile to clean out old eggs, allowing my environment to build after your recent version pinning. This isn't the full solution - we should be smart about when we do this rather than forcing users to run `make clean` when we change dependency versions.