### PR TITLE
Reviewer CNE: Define should_start

### DIFF
--- a/metaswitch/common/alarms.py
+++ b/metaswitch/common/alarms.py
@@ -121,6 +121,11 @@ class _AlarmManager(threading.Thread):
         Alarm handles should be of the following form:
         `(<index_number>, <severity1>, <severity2>, ...)`
         """
+
+        # We only want to start if we're not already running and we have an
+        # alarm, so we define this flag to track those criteria.
+        should_start = False
+
         # Prevent two threads from creating the same alarm object.
         with self._registry_lock:
             alarm = self._alarm_registry.get((issuer, alarm_handle), None)

--- a/metaswitch/common/test/test_alarms.py
+++ b/metaswitch/common/test/test_alarms.py
@@ -318,3 +318,17 @@ class TestAlarmManagerReSync(unittest.TestCase):
             alarm_manager.get_alarm('DummyIssuer', (2000, CLEARED, 6))
 
         mock_start.assert_called_once_with()
+
+    @mock.patch('metaswitch.common.alarms._sendrequest')
+    @mock.patch('metaswitch.common.alarms.atexit', autospec=True)
+    def test_alarm_requested_twice(self, mock_atexit, mock_sendrequest):
+        """Test that the alarm manager returns the same alarm object when it is
+        requested twice."""
+        alarm_manager = TestAlarmManager()
+
+        with mock.patch.object(alarm_manager, 'start') as mock_start:
+            alarm1 = alarm_manager.get_alarm('DummyIssuer', (1000, CLEARED, 4))
+            alarm2 = alarm_manager.get_alarm('DummyIssuer', (1000, CLEARED, 4))
+            self.assertEqual(alarm1, alarm2)
+
+        mock_start.assert_called_once_with()


### PR DESCRIPTION
Chris,

On nodes with multiple cluster-manager plugins, clearwater-cluster-manager is failing to start with the stack below. I believe this should fix it, and I'm just testing now. Does it look sensible to you?

```
09-03-2016 14:28:30.180 UTC ERROR logging_config.py:107 (thread MainThread): Uncaught exception:
  Exception: UnboundLocalError
  Detail: local variable 'should_start' referenced before assignment
  Traceback:
    File "/usr/share/clearwater/bin/clearwater-cluster-manager", line 40, in <module>
    main(sys.argv[1:])
  File "build_clustermgr/bdist.linux-x86_64/egg/metaswitch/clearwater/cluster_manager/main.py", line 194, in main
    syncer = EtcdSynchronizer(plugin, sig_ip, etcd_ip=mgmt_ip)
  File "build_clustermgr/bdist.linux-x86_64/egg/metaswitch/clearwater/cluster_manager/etcd_synchronizer.py", line 50, in __init__
    self._fsm = SyncFSM(self._plugin, self._ip)
  File "build_clustermgr/bdist.linux-x86_64/egg/metaswitch/clearwater/cluster_manager/synchronization_fsm.py", line 82, in __init__
    self._alarm = TooLongAlarm()
  File "build_clustermgr/bdist.linux-x86_64/egg/metaswitch/clearwater/cluster_manager/alarms.py", line 57, in __init__
    TOO_LONG_CLUSTERING)
  File "build/bdist.linux-x86_64/egg/metaswitch/common/alarms.py", line 151, in get_alarm
    if should_start:
```