### PR TITLE
[Reviewer: Rob] Alarm reliability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,8 @@ env: ${ENV_DIR}/.eggs_installed
 $(ENV_DIR)/bin/python:
 	# Set up a fresh virtual environment
 	virtualenv --setuptools --python=$(PYTHON_BIN) $(ENV_DIR)
-	$(ENV_DIR)/bin/easy_install "setuptools>0.7"
+	# We need to pull down >= 17.1 as Mock depends on it. We should probably find out why it wasn't working when set to version 0.7, as mock should have pulled what it needed.
+	$(ENV_DIR)/bin/easy_install "setuptools>=17.1"
 	$(ENV_DIR)/bin/easy_install distribute
 	$(ENV_DIR)/bin/pip install cffi
 
@@ -81,7 +82,7 @@ envclean:
 	rm -rf bin .eggs .develop-eggs parts .installed.cfg bootstrap.py .downloads .buildout_downloads
 	rm -rf distribute-*.tar.gz
 	rm -rf $(ENV_DIR)
-	rm metaswitch/common/_cffi.so *.o libclearwaterutils.a
+	rm -f metaswitch/common/_cffi.so *.o libclearwaterutils.a
 
 
 VPATH = cpp-common/src:cpp-common/include

--- a/metaswitch/common/alarms.py
+++ b/metaswitch/common/alarms.py
@@ -246,7 +246,7 @@ alarm_manager = _AlarmManager()
 class BaseAlarm(object):
     def __init__(self, issuer, index):
         self._clear_state = AlarmState(issuer, index, CLEARED)
-        self._last_state_raised = self._clear_state
+        self._last_state_raised = None
 
     def clear(self):
         """Send the alarm's cleared state to the alarm agent."""
@@ -255,7 +255,8 @@ class BaseAlarm(object):
 
     def re_sync(self):
         """Send or re-send the alarm's state to the alarm agent."""
-        self._last_state_raised.issue()
+        if self._last_state_raised != None:
+            self._last_state_raised.issue()
 
 
 class Alarm(BaseAlarm):

--- a/metaswitch/common/alarms.py
+++ b/metaswitch/common/alarms.py
@@ -255,7 +255,7 @@ class BaseAlarm(object):
 
     def re_sync(self):
         """Send or re-send the alarm's state to the alarm agent."""
-        if self._last_state_raised != None:
+        if self._last_state_raised is not None:
             self._last_state_raised.issue()
 
 


### PR DESCRIPTION
Starts Python alarms in `None` state. Checks that an alarm is not in `None` state before resyncing.

Also has a couple of fixes in the Makefile to ensure the right version of setuptools is installed, and to stop errors in make clean when some objects cannot be found to be deleted.