### PR TITLE
[Reviewer: Ellie] Map log levels from Clearwater to logging module

### DIFF
--- a/metaswitch/common/test/utils.py
+++ b/metaswitch/common/test/utils.py
@@ -32,6 +32,7 @@
 # under which the OpenSSL Project distributes the OpenSSL toolkit software,
 # as those licenses appear in the file LICENSE-OPENSSL.
 
+import logging
 import unittest
 from metaswitch.common.utils import _HUMAN_SAFE_ALPHABET, _URL_SAFE_ALPHABET, \
     create_secure_mixed_case_human_readable_id
@@ -47,6 +48,7 @@ from metaswitch.common.utils import (create_secure_human_readable_id,
                                      append_url_params,
                                      sip_uri_to_phone_number,
                                      sip_uri_to_domain,
+                                     map_clearwater_log_level,
                                      _pad,
                                      _un_pad)
 
@@ -173,6 +175,17 @@ class UtilsTestCase(unittest.TestCase):
                           "?bar=baz")
         self.assertEquals(append_url_params("foo#bif", bar="baz"),
                           "foo?bar=baz#bif")
+
+    def test_map_clearwater_log_level(self):
+        self.assertEquals(map_clearwater_log_level(-1), logging.ERROR)
+        self.assertEquals(map_clearwater_log_level(0), logging.ERROR)
+        self.assertEquals(map_clearwater_log_level(1), logging.WARNING)
+        self.assertEquals(map_clearwater_log_level(2), logging.INFO)
+        self.assertEquals(map_clearwater_log_level(3), logging.INFO)
+        self.assertEquals(map_clearwater_log_level(4), logging.DEBUG)
+        self.assertEquals(map_clearwater_log_level(5), logging.DEBUG)
+        self.assertEquals(map_clearwater_log_level(50), logging.DEBUG)
+
 
     def test_sip_uri_to_phone_number(self):
         self.assertEquals(sip_uri_to_phone_number("sip:1234@ngv.metaswitch.com"),

--- a/metaswitch/common/test/utils.py
+++ b/metaswitch/common/test/utils.py
@@ -177,15 +177,28 @@ class UtilsTestCase(unittest.TestCase):
                           "foo?bar=baz#bif")
 
     def test_map_clearwater_log_level(self):
-        self.assertEquals(map_clearwater_log_level(-1), logging.ERROR)
+        # Error
         self.assertEquals(map_clearwater_log_level(0), logging.ERROR)
-        self.assertEquals(map_clearwater_log_level(1), logging.WARNING)
-        self.assertEquals(map_clearwater_log_level(2), logging.INFO)
-        self.assertEquals(map_clearwater_log_level(3), logging.INFO)
-        self.assertEquals(map_clearwater_log_level(4), logging.DEBUG)
-        self.assertEquals(map_clearwater_log_level(5), logging.DEBUG)
-        self.assertEquals(map_clearwater_log_level(50), logging.DEBUG)
 
+        # Warning
+        self.assertEquals(map_clearwater_log_level(1), logging.WARNING)
+
+        # Status
+        self.assertEquals(map_clearwater_log_level(2, False), logging.WARNING)
+        self.assertEquals(map_clearwater_log_level(2, True), logging.INFO)
+        self.assertEquals(map_clearwater_log_level(2), logging.INFO)
+
+        # Info
+        self.assertEquals(map_clearwater_log_level(3), logging.INFO)
+
+        # Verbose
+        self.assertEquals(map_clearwater_log_level(4), logging.DEBUG)
+
+        # Debug
+        self.assertEquals(map_clearwater_log_level(5), logging.DEBUG)
+
+        self.assertEquals(map_clearwater_log_level(-1), logging.ERROR)
+        self.assertEquals(map_clearwater_log_level(50), logging.DEBUG)
 
     def test_sip_uri_to_phone_number(self):
         self.assertEquals(sip_uri_to_phone_number("sip:1234@ngv.metaswitch.com"),

--- a/metaswitch/common/utils.py
+++ b/metaswitch/common/utils.py
@@ -391,7 +391,7 @@ def write_core_file(process_name, contents): # pragma: no cover
 
 def install_sigusr1_handler(process_name): # pragma: no cover
     """
-    Install SIGUSR1 handler to dump stack."
+    Install SIGUSR1 handler to dump stack.
     """
     def sigusr1_handler(sig, stack):
         """
@@ -400,6 +400,29 @@ def install_sigusr1_handler(process_name): # pragma: no cover
         stack_dump = "Caught SIGUSR1\n" + "".join(traceback.format_stack(stack))
         write_core_file(process_name, stack_dump)
     signal.signal(signal.SIGUSR1, sigusr1_handler)
+
+def map_clearwater_log_level(level):
+    """
+    Map from Clearwater log levels to Python log levels.
+
+    Python doesn't have status or verbose levels, so these are mapped to
+    info and debug respectively.
+    """
+    LOG_LEVELS = {0: logging.ERROR,
+                  1: logging.WARNING,
+                  2: logging.INFO,
+                  3: logging.INFO,
+                  4: logging.DEBUG,
+                  5: logging.DEBUG}
+
+    level = int(level)
+
+    if level < 0:
+        level = 0
+    elif level > 5:
+        level = 5
+
+    return LOG_LEVELS[level]
 
 def lock_and_write_pid_file(filename): # pragma: no cover
     """ Attempts to write a pidfile, and returns the file object (to keep it

--- a/metaswitch/common/utils.py
+++ b/metaswitch/common/utils.py
@@ -401,16 +401,17 @@ def install_sigusr1_handler(process_name): # pragma: no cover
         write_core_file(process_name, stack_dump)
     signal.signal(signal.SIGUSR1, sigusr1_handler)
 
-def map_clearwater_log_level(level):
+def map_clearwater_log_level(level, status_as_info = True):
     """
     Map from Clearwater log levels to Python log levels.
 
-    Python doesn't have status or verbose levels, so these are mapped to
-    info and debug respectively.
+    Python doesn't have status or verbose levels. Verbose is mapped to debug,
+    and status is mapped to either info or warning, depending on the caller's
+    requirements.
     """
     LOG_LEVELS = {0: logging.ERROR,
                   1: logging.WARNING,
-                  2: logging.INFO,
+                  2: logging.INFO if status_as_info else logging.WARNING,
                   3: logging.INFO,
                   4: logging.DEBUG,
                   5: logging.DEBUG}


### PR DESCRIPTION
This commonalizes some of the function we have in clearwater-etcd and crest, so we can use it everywhere.

Typical call is:
```python
logging.configure_logging(utils.map_clearwater_log_level(args.log_level), ....)
```