### PR TITLE
[Reviewer: Ellie] Add safely_encode util method

### DIFF
--- a/metaswitch/common/test/utils.py
+++ b/metaswitch/common/test/utils.py
@@ -46,6 +46,7 @@ from metaswitch.common.utils import (create_secure_human_readable_id,
                                      hash_password,
                                      is_password_correct,
                                      append_url_params,
+                                     safely_encode,
                                      sip_uri_to_phone_number,
                                      sip_uri_to_domain,
                                      map_clearwater_log_level,
@@ -209,6 +210,11 @@ class UtilsTestCase(unittest.TestCase):
                           "abc.ngv.metaswitch.com")
         self.assertEquals(sip_uri_to_domain("sip:1234@xyz.ngv.metaswitch.com;gobbledygook"),
                           "xyz.ngv.metaswitch.com")
+
+    def test_safely_encode(self):
+        self.assertEquals(safely_encode(None), None)
+        self.assertEquals(safely_encode(u'ASCII'), 'ASCII')
+        self.assertEquals(safely_encode(u'\x80nonASCII'), '\xc2\x80nonASCII')
 
 if __name__ == "__main__":
     unittest.main()

--- a/metaswitch/common/utils.py
+++ b/metaswitch/common/utils.py
@@ -449,3 +449,9 @@ def lock_and_write_pid_file(filename): # pragma: no cover
 
     return lockfile
 
+def safely_encode(string):
+    result = None
+    if string:
+        result = string.encode("utf-8", errors="replace")
+    return result
+


### PR DESCRIPTION
Allowing us to log non-ASCII content

required for: https://github.com/Metaswitch/clearwater-etcd/pull/371