### PR TITLE
[Reviewer: Mat] - Tweaks to docs autogen code.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ env: ${ENV_DIR}/.eggs_installed
 
 $(ENV_DIR)/bin/python:
 	# Set up a fresh virtual environment
-	virtualenv --setuptools --python=$(PYTHON_BIN) $(ENV_DIR)
+	virtualenv --setuptools --no-download --python=$(PYTHON_BIN) $(ENV_DIR)
 	$(ENV_DIR)/bin/easy_install "setuptools==24"
 	$(ENV_DIR)/bin/easy_install distribute
 	$(ENV_DIR)/bin/pip install cffi

--- a/metaswitch/common/alarms_parser.py
+++ b/metaswitch/common/alarms_parser.py
@@ -57,6 +57,15 @@ alarm_model_state = {"cleared": 1,
                      "minor": 4,
                      "warning": 3}
 
+
+def full_alarm_oid(oid_fragment):
+    """
+    Convert OID fragments used in the alarm model into full OIDs.
+    """
+    # Prepend the OID prefix used by the alarm model for Clearwater
+    # alarms.
+    return "1.3.6.1.2.1.118.1.1.2.1.3.0." + oid_fragment
+
 # Valid causes - this should be kept in sync with the
 # list in alarmdefinition.h in cpp-common
 valid_causes = ["software_error",
@@ -258,7 +267,7 @@ def alarms_to_dita(alarms_files):
 
         for alarm in alarm_list:
             for alarm_level in alarm._levels.itervalues():
-                fields = {"OID": alarm_level._oid,
+                fields = {"OID": full_alarm_oid(alarm_level._oid),
                           "ITU severity": alarm_level._itu_severity,
                           "Cause": alarm._cause,
                           "Severity": alarm_level._severity_string,

--- a/metaswitch/common/alarms_parser.py
+++ b/metaswitch/common/alarms_parser.py
@@ -72,6 +72,7 @@ valid_causes = ["software_error",
                 "database_inconsistency",
                 "underlying_resource_unavailable"]
 
+
 class Alarm(object):
     # Takes Alarm JSON, verifies it and either throws an exception or
     # initializes an Alarm object representing the alarm.
@@ -82,7 +83,8 @@ class Alarm(object):
             self._levels = {}
 
             assert alarm['cause'].lower() in valid_causes, \
-                "Cause ({}) invalid in alarm {}".format(alarm['cause'], self._name)
+                "Cause ({}) invalid in alarm {}".format(alarm['cause'],
+                                                        self._name)
             self._cause = alarm['cause']
 
             found_cleared = False
@@ -100,13 +102,14 @@ class Alarm(object):
             # Check that there was a cleared severity level and at least one
             # non-cleared
             assert found_cleared, \
-                   "Alarm {} missing a cleared severity".format(self._name)
+                "Alarm {} missing a cleared severity".format(self._name)
             assert found_non_cleared, \
-                   "Alarm {} missing any non-cleared severities".format(self._name)
+                "Alarm {} missing any non-cleared severities".format(self._name)
 
         except KeyError as e:
             print "Invalid JSON format - missing mandatory value {}".format(e)
             raise
+
 
 class AlarmLevel(object):
     # Takes JSON representing a specific alarm level definition, verifies it
@@ -256,6 +259,7 @@ def alarms_to_csv(alarms_files):
 
     return output.getvalue()
 
+
 # Read in alarm information from a list of alarms files and generate a DITA
 # document describing the alarms.   Returns DITA as XML.
 def alarms_to_dita(alarms_files):
@@ -287,6 +291,7 @@ def alarms_to_dita(alarms_files):
     dita_content.end_section()
     return dita_content._xml
 
+
 # Read in alarm information from a list of alarms files and write a DITA
 # document describing them.
 def write_dita_file(alarms_files, dita_filename): #pragma: no cover
@@ -295,6 +300,7 @@ def write_dita_file(alarms_files, dita_filename): #pragma: no cover
     with open(dita_filename, "w") as dita_file:
         dita_file.write(xml)
 
+
 # Read in alarm information from a list of alarms files and write a CSV
 # document describing them.
 def write_csv_file(alarms_files, csv_filename): #pragma: no cover
@@ -302,4 +308,3 @@ def write_csv_file(alarms_files, csv_filename): #pragma: no cover
 
     with open(csv_filename, "w") as csv_file:
         csv_file.write(output)
-

--- a/metaswitch/common/alarms_parser.py
+++ b/metaswitch/common/alarms_parser.py
@@ -222,6 +222,7 @@ def validate_alarms_and_write_constants(json_file, constants_file): # pragma: no
     alarm_list = parse_alarms_file(json_file)
     write_constants_file(alarm_list, constants_file)
 
+
 # Read in alarm information from a list of alarms files and generate a CSV
 # document describing the alarms.   Returns CSV as a text string.
 def alarms_to_csv(alarms_files):

--- a/metaswitch/common/alarms_to_dita.py
+++ b/metaswitch/common/alarms_to_dita.py
@@ -44,4 +44,3 @@ args = parser.parse_args()
 dita_filename = os.path.join('.', args.output_dir, 'alarms.xml')
 
 write_dita_file(args.alarms_files, dita_filename)
-

--- a/metaswitch/common/dita_content.py
+++ b/metaswitch/common/dita_content.py
@@ -34,13 +34,18 @@
 # simple tables.  For an example of a DITA file constructed using this class,
 # see test/test_valid_alarms.dita.
 
+DOCTYPE_TAG = ('<!DOCTYPE concept PUBLIC "-//OASIS//DTD DITA Concept//EN"'
+               '"concept.dtd">\n')
+COLSPEC_TAG = '<colspec colname="c {0!s}" colnum="{1!s}" colwidth="{2}"/>\n'
+
+
 class DITAContent(object):
     def __init__(self):
         self._xml = ""
 
     def begin_section(self, doc_title):
         self._xml += '<?xml version="1.0" encoding="UTF-8"?>\n'
-        self._xml += '<!DOCTYPE concept PUBLIC "-//OASIS//DTD DITA Concept//EN" "concept.dtd">\n'
+        self._xml += DOCTYPE_TAG
         self._xml += '<concept>\n'
         self._xml += '<title>' + doc_title + '</title>\n'
         self._xml += '<conbody>\n'
@@ -51,7 +56,7 @@ class DITAContent(object):
         self._xml += '<tgroup cols="' + str(len(columns)) + '">\n'
 
         for index, column in enumerate(columns, start=1):
-            self._xml += '<colspec colname="c' + str(index) + '" colnum="' + str(index) + '" colwidth="' + widths[index-1] + '"/>\n'
+            self._xml += COLSPEC_TAG.format(index, index, widths[index - 1])
 
         self._xml += '<thead>\n'
         self._xml += '<row>\n'
@@ -75,4 +80,3 @@ class DITAContent(object):
         for value in data:
             self._xml += '<entry>\n<p>' + str(value) + '</p>\n</entry>\n'
         self._xml += '</row>\n'
-

--- a/metaswitch/common/dita_content.py
+++ b/metaswitch/common/dita_content.py
@@ -34,9 +34,9 @@
 # simple tables.  For an example of a DITA file constructed using this class,
 # see test/test_valid_alarms.dita.
 
-DOCTYPE_TAG = ('<!DOCTYPE concept PUBLIC "-//OASIS//DTD DITA Concept//EN"'
+DOCTYPE_TAG = ('<!DOCTYPE concept PUBLIC "-//OASIS//DTD DITA Concept//EN" '
                '"concept.dtd">\n')
-COLSPEC_TAG = '<colspec colname="c {0!s}" colnum="{1!s}" colwidth="{2}"/>\n'
+COLSPEC_TAG = '<colspec colname="c{0!s}" colnum="{1!s}" colwidth="{2}"/>\n'
 
 
 class DITAContent(object):

--- a/metaswitch/common/dita_content.py
+++ b/metaswitch/common/dita_content.py
@@ -53,11 +53,13 @@ class DITAContent(object):
         for index, column in enumerate(columns, start=1):
             self._xml += '<colspec colname="c' + str(index) + '" colnum="' + str(index) + '" colwidth="' + widths[index-1] + '"/>\n'
 
-        self._xml += '<tbody>\n'
+        self._xml += '<thead>\n'
         self._xml += '<row>\n'
         for column in columns:
             self._xml += '<entry>\n<p><b>' + column + '</b></p>\n</entry>\n'
         self._xml += '</row>\n'
+        self._xml += '</thead>\n'
+        self._xml += '<tbody>\n'
 
     def end_table(self):
         self._xml += '</tbody>\n'

--- a/metaswitch/common/stats_to_dita.py
+++ b/metaswitch/common/stats_to_dita.py
@@ -23,7 +23,24 @@ from dita_content import DITAContent
 # The column names (written as they are in the MIB file) that are to be
 # included.
 COLUMNS = ['SNMP NAME', 'OID', 'MAX-ACCESS', 'DESCRIPTION']
-COLUMN_WIDTHS = ["38%", "25%", "12%", "25%"]
+COLUMN_WIDTHS = ["40*", "29*", "11*", "20*"]
+
+# By default, column names are output in title caps. Use this dict to
+# override that e.g. for initialisms.
+COLUMN_OUTPUT_NAMES = {
+    'SNMP NAME': 'SNMP Name',
+    'OID': 'OID',
+}
+
+
+def get_column_name(column):
+    """
+    Get the display name to be output for the column.
+
+    Unless overridden in COLUMN_OUTPUT_NAMES, this will be the column name
+    in title caps.
+    """
+    return COLUMN_OUTPUT_NAMES.get(column, column.title())
 
 DEFAULT_OUTPUT_DIR = '.'
 
@@ -166,7 +183,7 @@ def write_dita_table(dictionary, table_oid, dita_content):
             table_oid:          The top level OID for the table
             dita_content:       A DITAContent object
     '''
-    heads = [word.title() for word in COLUMNS]
+    heads = [get_column_name(word) for word in COLUMNS]
     table_name = dictionary[table_oid].get_info('SNMP NAME')
 
     dita_content.begin_table(table_name, heads, COLUMN_WIDTHS)

--- a/metaswitch/common/stats_to_dita.py
+++ b/metaswitch/common/stats_to_dita.py
@@ -81,7 +81,7 @@ class Statistic(object):
                 self.details[item] = "N/A"
 
         with open('/dev/null', 'w') as the_bin:
-            command = ['snmptranslate', '-m' 'mib_file', oid]
+            command = ['snmptranslate', '-m', mib_file, oid]
             name = subprocess.check_output(command,
                                            stderr=the_bin)
 

--- a/metaswitch/common/stats_to_dita.py
+++ b/metaswitch/common/stats_to_dita.py
@@ -81,8 +81,10 @@ class Statistic(object):
                 self.details[item] = "N/A"
 
         with open('/dev/null', 'w') as the_bin:
-            name = subprocess.check_output('snmptranslate -m ' + mib_file + ' ' +
-                                           oid, stderr=the_bin, shell=True)
+            command = ['snmptranslate', '-m' 'mib_file', oid]
+            name = subprocess.check_output(command,
+                                           stderr=the_bin)
+
         # name is in the form  MID_FILE_NAME::snmp name
         self.details['SNMP NAME'] = name.split('::')[1].strip()
         self.details['OID'] = oid.strip()
@@ -109,10 +111,10 @@ class Statistic(object):
                                 single word or all words enclosed within {} or
                                 "".
         '''
-        get_details_cmd = 'snmptranslate -m ' + mib_file + ' -Td ' + oid
+        get_details_cmd = ['snmptranslate', '-m', mib_file, '-Td', oid]
         with open('/dev/null', 'w') as the_bin:
-            detail_string = subprocess.check_output(
-                get_details_cmd, stderr=the_bin, shell=True)
+            detail_string = subprocess.check_output(get_details_cmd,
+                                                    stderr=the_bin)
 
         in_quotes = False
         in_braces = False
@@ -142,8 +144,9 @@ def generate_oid_list(input_file):
     '''
     logger.info('Generating_OID_list from file: %s', input_file)
     with open('/dev/null', 'w') as the_bin:
-        oid_string = subprocess.check_output(
-            'snmptranslate -m ' + input_file + ' -To', stderr=the_bin, shell=True)
+        command = ['snmptranslate', '-m', input_file, '-To']
+        oid_string = subprocess.check_output(command,
+                                             stderr=the_bin)
         oid_list = oid_string.split()
     logger.debug('Generated OID list %s', oid_list)
     return oid_list

--- a/metaswitch/common/stats_to_dita.py
+++ b/metaswitch/common/stats_to_dita.py
@@ -5,10 +5,10 @@ A Script to generate DITA documentation of stats from a MIB file.
 Required packages:
 -SNMP Translate
 
-The script works by taking in a MIB file and running it through SNMP translate to
-obtain the details and OID's available. It then builds a dictionary of objects of
-class Statistic and then prints out the relevant data as DITA files.   Run with
--h to see the list of necessary parameters.
+The script works by taking in a MIB file and running it through SNMP translate
+to obtain the details and OID's available. It then builds a dictionary of
+objects of class Statistic and then prints out the relevant data as DITA
+files. Run with -h to see the list of necessary parameters.
 
 '''
 import subprocess
@@ -52,6 +52,7 @@ logging.basicConfig(level=logging.ERROR,
                     format='%(funcName)s - %(levelname)s - %(message)s')
 logger = logging.getLogger(__name__)
 
+
 class Statistic(object):
     ''' The class structure for each OID and its relevant information
     '''
@@ -59,11 +60,12 @@ class Statistic(object):
     def __init__(self, oid, mib_file, COLUMNS):
         '''
         Input
-        oid:                The specific OID for the statistic
-        mib_file:           The location of the MIB file defining the statistic
-        COLUMNS:            The properties of the statistic that we want to parse
+        oid:       The specific OID for the statistic
+        mib_file:  The location of the MIB file defining the statistic
+        COLUMNS:   The properties of the statistic that we want to parse
         '''
-        logger.info('Generating an element of class Statistic for OID: %s', oid)
+        logger.info('Generating an element of class Statistic for OID: %s',
+                    oid)
 
         self.details = {}
 
@@ -175,6 +177,7 @@ def write_dita_file(dita_filename, dita_title, table_oids, stats):
     with open(dita_filename, 'w') as output:
         output.write(dita_content._xml)
 
+
 def write_dita_table(dictionary, table_oid, dita_content):
     ''' generates a subsection containing a table in the XML
 
@@ -188,8 +191,8 @@ def write_dita_table(dictionary, table_oid, dita_content):
 
     dita_content.begin_table(table_name, heads, COLUMN_WIDTHS)
 
-    # Loop through the dictionary of all stats finding those that belong to this
-    # table.
+    # Loop through the dictionary of all stats finding those that belong to
+    # this table.
     for oid in sorted(dictionary):
         stat = dictionary[oid]
         if (oid.startswith(table_oid + '.') or (oid == table_oid)):
@@ -209,15 +212,18 @@ def write_dita_table(dictionary, table_oid, dita_content):
 
     dita_content.end_table()
 
+
 def should_output_stat(stat_name):
     if (white_list is None) and (black_list is None):
         return True
     if (white_list is not None) and (black_list is not None):
         if (stat_name in white_list) and (stat_name in black_list):
-            logger.error("Error: Stat %s is defined in both the whitelist and blacklist" % stat_name)
+            logger.error("Error: Stat %s is defined in both the whitelist "
+                         "and blacklist", stat_name)
             sys.exit(1)
         if (stat_name not in white_list) and (stat_name not in black_list):
-            logger.error("Error: Stat %s is not defined in either the whitelist or blacklist" % stat_name)
+            logger.error("Error: Stat %s is not defined in either the "
+                         "whitelist or blacklist", stat_name)
             sys.exit(1)
         return stat_name in white_list
     if (white_list is not None):
@@ -229,20 +235,28 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(
         description='Translates a MIB file for a set of statistics to a set of'
                     ' DITA documents describing them.')
-    parser.add_argument('filename', metavar='FILENAME',
-                        help='The MIB file you wish to generate your document from')
-    parser.add_argument('--oid-base-len', action='store',
-                        help='The length of the base OID -- an output file will'
-                             ' be generated for each OID with length'
-                             ' oid-base-len.   All OIDs with length <'
-                             ' oid-base-len will be ignored.')
-    parser.add_argument('--output-dir', action='store',
-                        help='The directory that the output DITA files should be written to')
-    parser.add_argument('--config-file', action='store',
-                        help='An optional JSON configuration file defining'
-                        ' arrays of top level objects to ignore (ignore_list),'
-                        ' individual stats to whitelist (whitelist) and stats'
-                        ' to blacklist (blacklist).')
+    parser.add_argument(
+        'filename',
+        metavar='FILENAME',
+        help='The MIB file you wish to generate your document from')
+    parser.add_argument(
+        '--oid-base-len',
+        action='store',
+        help='The length of the base OID -- an output file will'
+             ' be generated for each OID with length'
+             ' oid-base-len.   All OIDs with length <'
+             ' oid-base-len will be ignored.')
+    parser.add_argument(
+        '--output-dir',
+        action='store',
+        help='The directory that the output DITA files should be written to')
+    parser.add_argument(
+        '--config-file',
+        action='store',
+        help='An optional JSON configuration file defining'
+             ' arrays of top level objects to ignore (ignore_list),'
+             ' individual stats to whitelist (whitelist) and stats'
+             ' to blacklist (blacklist).')
     args = vars(parser.parse_args())
 
     if args['output_dir']:
@@ -290,7 +304,7 @@ if __name__ == '__main__':
 
     for file_oid, table_oids in file_and_table_oids.iteritems():
         file_oid_name = stats[file_oid].get_info('SNMP NAME')
-        write_dita_file(output_name + '_' +  file_oid_name + '.xml',
+        write_dita_file(output_name + '_' + file_oid_name + '.xml',
                         file_oid_name,
                         table_oids,
                         stats)

--- a/metaswitch/common/test/test_valid_alarms.dita
+++ b/metaswitch/common/test/test_valid_alarms.dita
@@ -8,7 +8,7 @@
 <tgroup cols="2">
 <colspec colname="c1" colnum="1" colwidth="25%"/>
 <colspec colname="c2" colnum="2" colwidth="75%"/>
-<tbody>
+<thead>
 <row>
 <entry>
 <p><b>Field</b></p>
@@ -17,6 +17,8 @@
 <p><b>Value</b></p>
 </entry>
 </row>
+</thead>
+<tbody>
 <row>
 <entry>
 <p>Action</p>
@@ -54,7 +56,7 @@
 <p>OID</p>
 </entry>
 <entry>
-<p>1000.1</p>
+<p>1.3.6.1.2.1.118.1.1.2.1.3.0.1000.1</p>
 </entry>
 </row>
 <row>
@@ -89,7 +91,7 @@
 <tgroup cols="2">
 <colspec colname="c1" colnum="1" colwidth="25%"/>
 <colspec colname="c2" colnum="2" colwidth="75%"/>
-<tbody>
+<thead>
 <row>
 <entry>
 <p><b>Field</b></p>
@@ -98,6 +100,8 @@
 <p><b>Value</b></p>
 </entry>
 </row>
+</thead>
+<tbody>
 <row>
 <entry>
 <p>Action</p>
@@ -135,7 +139,7 @@
 <p>OID</p>
 </entry>
 <entry>
-<p>1000.6</p>
+<p>1.3.6.1.2.1.118.1.1.2.1.3.0.1000.6</p>
 </entry>
 </row>
 <row>


### PR DESCRIPTION
Ellie, you reviewed @MatMeredith 's original changes here. Can you please review this too?

At request from docs group:
* Changed column widths to stop OIDs overrunning into the next column.
* Use thead for the title rows of tables.
* Capitalized initialisms in column titles.
* Use * instead of % in column widths for compatibility with tools used
  by docs group.

For easier-to-use docs, include entire OID in alarm tables.

Fixed up PEP8 in the files I touched, and fixed up subprocess to use safer semantics.