### PR TITLE
Refactor dita function from alarms_parser

### DIFF
--- a/metaswitch/common/alarms_parser.py
+++ b/metaswitch/common/alarms_parser.py
@@ -34,7 +34,6 @@ import json
 import StringIO
 import csv
 import alarm_severities
-from dita_content import DITAContent
 
 # Valid severity levels - this should be kept in sync with the
 # list in alarmdefinition.h in cpp-common
@@ -259,47 +258,6 @@ def alarms_to_csv(alarms_files):
                 writer.writerow(values)
 
     return output.getvalue()
-
-
-# Read in alarm information from a list of alarms files and generate a DITA
-# document describing the alarms.   Returns DITA as XML.
-def alarms_to_dita(alarms_files):
-    dita_content = DITAContent()
-    dita_content.begin_section("Alarms")
-
-    for alarm_file in alarms_files:
-        alarm_list = parse_alarms_file(alarm_file)
-
-        for alarm in alarm_list:
-            for alarm_level in alarm._levels.itervalues():
-                fields = {"OID": full_alarm_oid(alarm_level._oid),
-                          "ITU severity": alarm_level._itu_severity,
-                          "Cause": alarm._cause,
-                          "Severity": alarm_level._severity_string,
-                          "Description": alarm_level._description,
-                          "Details": alarm_level._details,
-                          "Cause": alarm_level._cause,
-                          "Effect": alarm_level._effect,
-                          "Action": alarm_level._action}
-
-                dita_content.begin_table(alarm._name + ": " + alarm_level._severity_string,
-                                         ["Field", "Value"],
-                                         ["25%", "75%"])
-                for field, value in fields.iteritems():
-                    dita_content.add_table_entry([field, value])
-                dita_content.end_table()
-
-    dita_content.end_section()
-    return dita_content._xml
-
-
-# Read in alarm information from a list of alarms files and write a DITA
-# document describing them.
-def write_dita_file(alarms_files, dita_filename): #pragma: no cover
-    xml = alarms_to_dita(alarms_files)
-
-    with open(dita_filename, "w") as dita_file:
-        dita_file.write(xml)
 
 
 # Read in alarm information from a list of alarms files and write a CSV

--- a/metaswitch/common/alarms_to_dita.py
+++ b/metaswitch/common/alarms_to_dita.py
@@ -34,13 +34,61 @@
 
 import argparse
 import os
-from alarms_parser import write_dita_file
+import alarms_parser
+from dita_content import DITAContent
 
-parser = argparse.ArgumentParser()
-parser.add_argument('--alarms-files', nargs="*", type=str, required=True)
-parser.add_argument('--output-dir', type=str, required=True)
-args = parser.parse_args()
 
-dita_filename = os.path.join('.', args.output_dir, 'alarms.xml')
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--alarms-files', nargs="*", type=str, required=True)
+    parser.add_argument('--output-dir', type=str, required=True)
+    args = parser.parse_args()
 
-write_dita_file(args.alarms_files, dita_filename)
+    dita_filename = os.path.join('.', args.output_dir, 'alarms.xml')
+
+    write_dita_file(args.alarms_files, dita_filename)
+
+
+# Read in alarm information from a list of alarms files and write a DITA
+# document describing them.
+def write_dita_file(alarms_files, dita_filename): #pragma: no cover
+    xml = alarms_to_dita(alarms_files)
+
+    with open(dita_filename, "w") as dita_file:
+        dita_file.write(xml)
+
+
+# Read in alarm information from a list of alarms files and generate a DITA
+# document describing the alarms.   Returns DITA as XML.
+def alarms_to_dita(alarms_files):
+    dita_content = DITAContent()
+    dita_content.begin_section("Alarms")
+
+    for alarm_file in alarms_files:
+        alarm_list = alarms_parser.parse_alarms_file(alarm_file)
+
+        for alarm in alarm_list:
+            for alarm_level in alarm._levels.itervalues():
+                fields = {"OID": alarms_parser.full_alarm_oid(alarm_level._oid),
+                          "ITU severity": alarm_level._itu_severity,
+                          "Cause": alarm._cause,
+                          "Severity": alarm_level._severity_string,
+                          "Description": alarm_level._description,
+                          "Details": alarm_level._details,
+                          "Cause": alarm_level._cause,
+                          "Effect": alarm_level._effect,
+                          "Action": alarm_level._action}
+
+                dita_content.begin_table(alarm._name + ": " + alarm_level._severity_string,
+                                         ["Field", "Value"],
+                                         ["25%", "75%"])
+                for field, value in fields.iteritems():
+                    dita_content.add_table_entry([field, value])
+                dita_content.end_table()
+
+    dita_content.end_section()
+    return dita_content._xml
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
As preparation to split out all docs tools to https://github.com/Metaswitch/clearwater-docs-tools, this pull request refactors `alarms_to_dita` and `write_dita_file` from `alarms_parser` to `alarms_to_dita`, so that the module `dita_content` doesn't get imported anywhere else than the actual docs tool scripts.