### PR TITLE
Revert "Refactor dita function from alarms_parser"

### DIFF
--- a/metaswitch/common/alarms_parser.py
+++ b/metaswitch/common/alarms_parser.py
@@ -34,6 +34,7 @@ import json
 import StringIO
 import csv
 import alarm_severities
+from dita_content import DITAContent
 
 # Valid severity levels - this should be kept in sync with the
 # list in alarmdefinition.h in cpp-common
@@ -258,6 +259,47 @@ def alarms_to_csv(alarms_files):
                 writer.writerow(values)
 
     return output.getvalue()
+
+
+# Read in alarm information from a list of alarms files and generate a DITA
+# document describing the alarms.   Returns DITA as XML.
+def alarms_to_dita(alarms_files):
+    dita_content = DITAContent()
+    dita_content.begin_section("Alarms")
+
+    for alarm_file in alarms_files:
+        alarm_list = parse_alarms_file(alarm_file)
+
+        for alarm in alarm_list:
+            for alarm_level in alarm._levels.itervalues():
+                fields = {"OID": full_alarm_oid(alarm_level._oid),
+                          "ITU severity": alarm_level._itu_severity,
+                          "Cause": alarm._cause,
+                          "Severity": alarm_level._severity_string,
+                          "Description": alarm_level._description,
+                          "Details": alarm_level._details,
+                          "Cause": alarm_level._cause,
+                          "Effect": alarm_level._effect,
+                          "Action": alarm_level._action}
+
+                dita_content.begin_table(alarm._name + ": " + alarm_level._severity_string,
+                                         ["Field", "Value"],
+                                         ["25%", "75%"])
+                for field, value in fields.iteritems():
+                    dita_content.add_table_entry([field, value])
+                dita_content.end_table()
+
+    dita_content.end_section()
+    return dita_content._xml
+
+
+# Read in alarm information from a list of alarms files and write a DITA
+# document describing them.
+def write_dita_file(alarms_files, dita_filename): #pragma: no cover
+    xml = alarms_to_dita(alarms_files)
+
+    with open(dita_filename, "w") as dita_file:
+        dita_file.write(xml)
 
 
 # Read in alarm information from a list of alarms files and write a CSV

--- a/metaswitch/common/alarms_to_dita.py
+++ b/metaswitch/common/alarms_to_dita.py
@@ -34,61 +34,13 @@
 
 import argparse
 import os
-import alarms_parser
-from dita_content import DITAContent
+from alarms_parser import write_dita_file
 
+parser = argparse.ArgumentParser()
+parser.add_argument('--alarms-files', nargs="*", type=str, required=True)
+parser.add_argument('--output-dir', type=str, required=True)
+args = parser.parse_args()
 
-def main():
-    parser = argparse.ArgumentParser()
-    parser.add_argument('--alarms-files', nargs="*", type=str, required=True)
-    parser.add_argument('--output-dir', type=str, required=True)
-    args = parser.parse_args()
+dita_filename = os.path.join('.', args.output_dir, 'alarms.xml')
 
-    dita_filename = os.path.join('.', args.output_dir, 'alarms.xml')
-
-    write_dita_file(args.alarms_files, dita_filename)
-
-
-# Read in alarm information from a list of alarms files and write a DITA
-# document describing them.
-def write_dita_file(alarms_files, dita_filename): #pragma: no cover
-    xml = alarms_to_dita(alarms_files)
-
-    with open(dita_filename, "w") as dita_file:
-        dita_file.write(xml)
-
-
-# Read in alarm information from a list of alarms files and generate a DITA
-# document describing the alarms.   Returns DITA as XML.
-def alarms_to_dita(alarms_files):
-    dita_content = DITAContent()
-    dita_content.begin_section("Alarms")
-
-    for alarm_file in alarms_files:
-        alarm_list = alarms_parser.parse_alarms_file(alarm_file)
-
-        for alarm in alarm_list:
-            for alarm_level in alarm._levels.itervalues():
-                fields = {"OID": alarms_parser.full_alarm_oid(alarm_level._oid),
-                          "ITU severity": alarm_level._itu_severity,
-                          "Cause": alarm._cause,
-                          "Severity": alarm_level._severity_string,
-                          "Description": alarm_level._description,
-                          "Details": alarm_level._details,
-                          "Cause": alarm_level._cause,
-                          "Effect": alarm_level._effect,
-                          "Action": alarm_level._action}
-
-                dita_content.begin_table(alarm._name + ": " + alarm_level._severity_string,
-                                         ["Field", "Value"],
-                                         ["25%", "75%"])
-                for field, value in fields.iteritems():
-                    dita_content.add_table_entry([field, value])
-                dita_content.end_table()
-
-    dita_content.end_section()
-    return dita_content._xml
-
-
-if __name__ == "__main__":
-    main()
+write_dita_file(args.alarms_files, dita_filename)


### PR DESCRIPTION
Reverts Metaswitch/python-common#85.

The build http://repo.cw-ngv.com:8080/job/python-common/220/console broke with:
```
cc -Icpp-common/include -fno-strict-aliasing -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -fPIC -I/usr/include/python2.7 -c build/temp.linux-x86_64-2.7/_cffi.c -o build/temp.linux-x86_64-2.7/build/temp.linux-x86_64-2.7/_cffi.o
x86_64-linux-gnu-gcc -pthread -shared -Wl,-O1 -Wl,-Bsymbolic-functions -Wl,-Bsymbolic-functions -Wl,-z,relro -fno-strict-aliasing -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -D_FORTIFY_SOURCE=2 -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security build/temp.linux-x86_64-2.7/build/temp.linux-x86_64-2.7/_cffi.o -lclearwaterutils -lstdc++ -o /var/lib/jenkins/slave/workspace/python-common/metaswitch/common/_cffi.so
Traceback (most recent call last):
  File "setup.py", line 57, in <module>
    tests_require=["pbr==1.6", "Mock", "phonenumbers==7.1.1"]
  File "/usr/lib/python2.7/distutils/core.py", line 151, in setup
    dist.run_commands()
  File "/usr/lib/python2.7/distutils/dist.py", line 953, in run_commands
    self.run_command(cmd)
  File "/usr/lib/python2.7/distutils/dist.py", line 972, in run_command
    cmd_obj.run()
  File "build/bdist.linux-x86_64/egg/setuptools/command/test.py", line 170, in run
  File "build/bdist.linux-x86_64/egg/setuptools/command/test.py", line 191, in run_tests
  File "/usr/lib/python2.7/unittest/main.py", line 94, in __init__
    self.parseArgs(argv)
  File "/usr/lib/python2.7/unittest/main.py", line 149, in parseArgs
    self.createTests()
  File "/usr/lib/python2.7/unittest/main.py", line 158, in createTests
    self.module)
  File "/usr/lib/python2.7/unittest/loader.py", line 130, in loadTestsFromNames
    suites = [self.loadTestsFromName(name, module) for name in names]
  File "/usr/lib/python2.7/unittest/loader.py", line 103, in loadTestsFromName
    return self.loadTestsFromModule(obj)
  File "build/bdist.linux-x86_64/egg/setuptools/command/test.py", line 39, in loadTestsFromModule
  File "/usr/lib/python2.7/unittest/loader.py", line 100, in loadTestsFromName
    parent, obj = obj, getattr(obj, part)
AttributeError: 'module' object has no attribute 'alarms_parser'
make: *** [test] Error 1
```