### PR TITLE
git Flake8 fixes for mib.py

### DIFF
--- a/metaswitch/common/alarms_parser.py
+++ b/metaswitch/common/alarms_parser.py
@@ -274,7 +274,6 @@ def alarms_to_dita(alarms_files):
             for alarm_level in alarm._levels.itervalues():
                 fields = {"OID": full_alarm_oid(alarm_level._oid),
                           "ITU severity": alarm_level._itu_severity,
-                          "Cause": alarm._cause,
                           "Severity": alarm_level._severity_string,
                           "Description": alarm_level._description,
                           "Details": alarm_level._details,

--- a/metaswitch/common/generate_stats_csv.py
+++ b/metaswitch/common/generate_stats_csv.py
@@ -1,19 +1,21 @@
 """Generate detailed statistics documentation.
 
 This script takes a number of MIB files and merges them with a CSV file
-containing additional data, to create an output CSV file suitable for
-sharing with RFP central and SAs.
+containing additional data, to create an output CSV file suitable for sharing
+with RFP central and SAs. If there are any duplicate keys in the provided MIB
+files, the initial value gets overwritten by any occurrence in a MIB file that
+was provided after the MIB file with the first occurrence.
 
-This is not intended to create a document suitable for sharing directly
-with customers, but it should make it simple for our customer-facing
-teams to make such documents.
+This is not intended to create a document suitable for sharing directly with
+customers, but it should make it simple for our customer-facing teams to make
+such documents.
 
 An error-level log is output for each:
 * Item in the MIB files that doesn't have corresponding extra CSV data.
 * Item in the CSV file that can't be found in the MIB files.
 
-To set the logging level, set the LOGGING_LEVEL environemnt variable
-to the name of a standard Python logging level e.g. DEBUG.
+To set the logging level, set the LOGGING_LEVEL environemnt variable to the
+name of a standard Python logging level e.g. DEBUG.
 """
 # To add new fields to the output CSV:
 # * Determine where the field comes from and add it to either
@@ -29,6 +31,7 @@ import csv
 import StringIO
 import sys
 import collections
+from argparse import RawTextHelpFormatter
 import mib
 
 logger = logging.getLogger(__name__)
@@ -121,7 +124,8 @@ def setup_logging():
 
 def parse_args():
     """Get the command-line arguments."""
-    parser = argparse.ArgumentParser(description=__doc__)
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=RawTextHelpFormatter)
     parser.add_argument('mib_files', metavar='MIB', nargs='+',
                         help='The absolute path(s) of the input MIB(s).')
     parser.add_argument('csv_file', metavar='CSV',
@@ -141,9 +145,10 @@ def parse_mib_files(mib_files):
     disk.
     Returns a dict keyed by (MIB table name, MIB field name) with values
     (Source File, MIB table description, OID, MIB field description).
-    If there are any duplicate keys in the provided MIB files, the initial
-    value gets overwritten by any occurrence in a MIB file that was provided
-    after the MIB file with the first occurrence on the command line.
+    Some MIB values can appear in multiple MIB file so there should be a
+    preference by the user which MIB file should have precedence. So if there
+    are any duplicate values in several MIB files these get overwritten by the
+    later provided files on the command line.
     """
     output = {}
     for mib_file in mib_files:

--- a/metaswitch/common/generate_stats_csv.py
+++ b/metaswitch/common/generate_stats_csv.py
@@ -141,6 +141,9 @@ def parse_mib_files(mib_files):
     disk.
     Returns a dict keyed by (MIB table name, MIB field name) with values
     (Source File, MIB table description, OID, MIB field description).
+    If there are any duplicate keys in the provided MIB files, the initial
+    value gets overwritten by any occurrence in a MIB file that was provided
+    after the MIB file with the first occurrence on the command line.
     """
     output = {}
     for mib_file in mib_files:

--- a/metaswitch/common/mib.py
+++ b/metaswitch/common/mib.py
@@ -40,7 +40,7 @@ class MibFile(object):
         """
         # Add INDEX to the list of fields to retrieve and parse - we
         # need this in order to check whether a node is a statistic or not.
-        if not "INDEX" in columns:
+        if "INDEX" not in columns:
             columns.append("INDEX")
 
         stats = {oid: Statistic(oid, self.path, columns) for
@@ -144,7 +144,7 @@ class Statistic(object):
         # Implementation is to look back through the parents of this node
         # until we find one with "Table" in it's name.
         def table_test(stat):
-            return True if  "Table" in stat.get_info("SNMP NAME") else False
+            return True if "Table" in stat.get_info("SNMP NAME") else False
 
         if not self._table:
             for ancestor in self.ancestors():
@@ -159,8 +159,7 @@ class Statistic(object):
 
         return self._table
 
-
-    def is_index_field (self):
+    def is_index_field(self):
         """Determine if this is an index field or not by stepping back through
         the ancestors inside the table.
 
@@ -186,8 +185,8 @@ class Statistic(object):
                              ancestor_index_string)
 
                 if ancestor_index_string:
-                    ancestor_index_fields = [x.strip()
-                                     for x in ancestor_index_string.split(',')]
+                    ancestor_index_fields = [
+                        x.strip() for x in ancestor_index_string.split(',')]
                     if field_name in ancestor_index_fields:
                         logger.debug("%s is an index field", field_name)
                         return True
@@ -199,7 +198,6 @@ class Statistic(object):
 
         return False
 
-
     def get_data(self, columns):
         ''' Gets the data from a stat. If the stat is an intermediate node or
             blacklisted, returns None.
@@ -209,15 +207,12 @@ class Statistic(object):
         '''
         data = None
 
-        # If MAX-ACCESS is N/A, this is an intermediate node of no interest, and
-        # we skip it.
-        if not stat.get_info('MAX-ACCESS') == "N/A":
-            stat_name = stat.get_info('SNMP NAME')
-            if should_output_stat(stat_name):
-                data = [stat.get_info(detail) for detail in columns]
+        # If MAX-ACCESS is N/A, this is an intermediate node of no interest,
+        # and we skip it.
+        if self.get_info('MAX-ACCESS') != "N/A":
+            data = [self.get_info(detail) for detail in columns]
 
         return data
-
 
     def __str__(self):
         return self.details['SNMP NAME']
@@ -227,6 +222,7 @@ class memoize(collections.defaultdict):
     """Memoize the return values from a function."""
     def __call__(self, *args):
         return self[args]
+
     def __missing__(self, args):
         value = self.default_factory(*args)
         self[args] = value


### PR DESCRIPTION
Unfortunately we broke the python-common build last week by updating some doc generation scripts. The build failed because of some flake8 problems that sneaked into `mib.py`: http://repo.cw-ngv.com:8080/job/python-common/221/changes. 
I have fixed up the `mib.py` flake8 errors and spotted while doing this that `alarms_parser.py` includes a bug (duplicated Python dictionary key) that flake8 spotted when running it locally on my checkout. I have fixed this as well after talking with MGM and deleted the unused key. I have checked that the script still produces the exact same output as before which the docs team are apparently happy with.
Additionally I've added a comment to `generate_stats_csv.py` describing how the script handles duplicates in the input MIB files.

Running `make verify` on the python-common checkout with these fixes works fine, so this should hopefully fix the build. SR2 just mentioned that we need to follow https://metacom.metaswitch.com/docs/DOC-95461 once the build job for python-common succeeds again.