### PR TITLE
Stats to DITA fix

### DIFF
--- a/metaswitch/common/alarms_parser.py
+++ b/metaswitch/common/alarms_parser.py
@@ -274,7 +274,6 @@ def alarms_to_dita(alarms_files):
             for alarm_level in alarm._levels.itervalues():
                 fields = {"OID": full_alarm_oid(alarm_level._oid),
                           "ITU severity": alarm_level._itu_severity,
-                          "Cause": alarm._cause,
                           "Severity": alarm_level._severity_string,
                           "Description": alarm_level._description,
                           "Details": alarm_level._details,

--- a/metaswitch/common/generate_stats_csv.py
+++ b/metaswitch/common/generate_stats_csv.py
@@ -141,6 +141,9 @@ def parse_mib_files(mib_files):
     disk.
     Returns a dict keyed by (MIB table name, MIB field name) with values
     (Source File, MIB table description, OID, MIB field description).
+    If there are any duplicate keys in the provided MIB files, the initial
+    value gets overwritten by any occurrence in a MIB file that was provided
+    after the MIB file with the first occurrence on the command line.
     """
     output = {}
     for mib_file in mib_files:

--- a/metaswitch/common/mib.py
+++ b/metaswitch/common/mib.py
@@ -38,15 +38,7 @@ class MibFile(object):
         `columns` should be a list of the properties of the statistic that we
         want to parse.
         """
-        # Add INDEX to the list of fields to retrieve and parse - we
-        # need this in order to check whether a node is a statistic or not.
-        # To do this we use a copy of columns to keep ownership of columns in
-        # the calling script.
-        columns_copy = columns[:]
-        if "INDEX" not in columns_copy:
-            columns_copy.append("INDEX")
-
-        stats = {oid: Statistic(oid, self.path, columns_copy) for
+        stats = {oid: Statistic(oid, self.path, columns) for
                  oid in self.oids}
         return stats
 
@@ -81,9 +73,17 @@ class Statistic(object):
         self._parent = None
 
         self.mib_file = mib_file
-        self.columns = columns
         self.details = {}
         self.oid = oid
+
+        # Add INDEX to the list of fields to retrieve and parse - we
+        # need this in order to check whether a node is a statistic or not.
+        # To do so use a copy of columns to not take ownership of the passed
+        # parameter.
+        columns_copy = columns[:]
+        if "INDEX" not in columns_copy:
+            columns_copy.append("INDEX")
+        self.columns = columns_copy
 
         tokenized_details = _get_tokenized_mib_details(mib_file, oid)
 

--- a/metaswitch/common/mib.py
+++ b/metaswitch/common/mib.py
@@ -40,7 +40,7 @@ class MibFile(object):
         """
         # Add INDEX to the list of fields to retrieve and parse - we
         # need this in order to check whether a node is a statistic or not.
-        if not "INDEX" in columns:
+        if "INDEX" not in columns:
             columns.append("INDEX")
 
         stats = {oid: Statistic(oid, self.path, columns) for
@@ -144,7 +144,7 @@ class Statistic(object):
         # Implementation is to look back through the parents of this node
         # until we find one with "Table" in it's name.
         def table_test(stat):
-            return True if  "Table" in stat.get_info("SNMP NAME") else False
+            return True if "Table" in stat.get_info("SNMP NAME") else False
 
         if not self._table:
             for ancestor in self.ancestors():
@@ -159,8 +159,7 @@ class Statistic(object):
 
         return self._table
 
-
-    def is_index_field (self):
+    def is_index_field(self):
         """Determine if this is an index field or not by stepping back through
         the ancestors inside the table.
 
@@ -186,8 +185,8 @@ class Statistic(object):
                              ancestor_index_string)
 
                 if ancestor_index_string:
-                    ancestor_index_fields = [x.strip()
-                                     for x in ancestor_index_string.split(',')]
+                    ancestor_index_fields = [
+                        x.strip() for x in ancestor_index_string.split(',')]
                     if field_name in ancestor_index_fields:
                         logger.debug("%s is an index field", field_name)
                         return True
@@ -199,7 +198,6 @@ class Statistic(object):
 
         return False
 
-
     def get_data(self, columns):
         ''' Gets the data from a stat. If the stat is an intermediate node or
             blacklisted, returns None.
@@ -209,15 +207,12 @@ class Statistic(object):
         '''
         data = None
 
-        # If MAX-ACCESS is N/A, this is an intermediate node of no interest, and
-        # we skip it.
-        if not stat.get_info('MAX-ACCESS') == "N/A":
-            stat_name = stat.get_info('SNMP NAME')
-            if should_output_stat(stat_name):
-                data = [stat.get_info(detail) for detail in columns]
+        # If MAX-ACCESS is N/A, this is an intermediate node of no interest,
+        # and we skip it.
+        if self.get_info('MAX-ACCESS') != "N/A":
+            data = [self.get_info(detail) for detail in columns]
 
         return data
-
 
     def __str__(self):
         return self.details['SNMP NAME']
@@ -227,6 +222,7 @@ class memoize(collections.defaultdict):
     """Memoize the return values from a function."""
     def __call__(self, *args):
         return self[args]
+
     def __missing__(self, args):
         value = self.default_factory(*args)
         self[args] = value

--- a/metaswitch/common/mib.py
+++ b/metaswitch/common/mib.py
@@ -40,10 +40,13 @@ class MibFile(object):
         """
         # Add INDEX to the list of fields to retrieve and parse - we
         # need this in order to check whether a node is a statistic or not.
-        if "INDEX" not in columns:
-            columns.append("INDEX")
+        # To do this we use a copy of columns to keep ownership of columns in
+        # the calling script.
+        columns_copy = columns[:]
+        if "INDEX" not in columns_copy:
+            columns_copy.append("INDEX")
 
-        stats = {oid: Statistic(oid, self.path, columns) for
+        stats = {oid: Statistic(oid, self.path, columns_copy) for
                  oid in self.oids}
         return stats
 

--- a/metaswitch/common/stats_to_dita.py
+++ b/metaswitch/common/stats_to_dita.py
@@ -17,7 +17,6 @@ import argparse
 import os
 import sys
 import json
-import copy
 import mib
 from dita_content import DITAContent
 
@@ -169,10 +168,7 @@ if __name__ == '__main__':
     mib_file = mib.MibFile(input_file)
 
     # Generates a dictionary holding a Statistic for every OID in the OID list.
-    # Pass in a copy of COLUMNS to keep ownership of this constant here as
-    # the Statistics class might modify it.
-    columns_copy = copy.copy(COLUMNS)
-    stats = mib_file.get_all_stats(columns_copy)
+    stats = mib_file.get_all_stats(COLUMNS)
 
     # The OIDs at level oid_base_len will become individual output files
     # The OIDs at level oid_base_len+1 will become tables within those output

--- a/metaswitch/common/stats_to_dita.py
+++ b/metaswitch/common/stats_to_dita.py
@@ -17,6 +17,7 @@ import argparse
 import os
 import sys
 import json
+import copy
 import mib
 from dita_content import DITAContent
 
@@ -167,8 +168,11 @@ if __name__ == '__main__':
 
     mib_file = mib.MibFile(input_file)
 
-    # Generates a dictionary holding a Statistic for every OID in the OID list
-    stats = mib_file.get_all_stats(COLUMNS)
+    # Generates a dictionary holding a Statistic for every OID in the OID list.
+    # Pass in a copy of COLUMNS to keep ownership of this constant here as
+    # the Statistics class might modify it.
+    columns_copy = copy.copy(COLUMNS)
+    stats = mib_file.get_all_stats(columns_copy)
 
     # The OIDs at level oid_base_len will become individual output files
     # The OIDs at level oid_base_len+1 will become tables within those output


### PR DESCRIPTION
This pull request is fixing https://github.com/Metaswitch/clearwater-issues/issues/2091. The problem was that there wasn't clear ownership of the COLUMNS in `stats_to_dita.py` which got implicitly modified by the `Statistics` class. I have fixed this up by passing a copy of `COLUMNS` rather than `COLUMNS` itself to the initializer of a `Statistics` object.