### PR TITLE
Refactor alarms_parser dependency on dita_content

### DIFF
--- a/metaswitch/common/alarms_parser.py
+++ b/metaswitch/common/alarms_parser.py
@@ -34,7 +34,6 @@ import json
 import StringIO
 import csv
 import alarm_severities
-from dita_content import DITAContent
 
 # Valid severity levels - this should be kept in sync with the
 # list in alarmdefinition.h in cpp-common
@@ -259,46 +258,6 @@ def alarms_to_csv(alarms_files):
                 writer.writerow(values)
 
     return output.getvalue()
-
-
-# Read in alarm information from a list of alarms files and generate a DITA
-# document describing the alarms.   Returns DITA as XML.
-def alarms_to_dita(alarms_files):
-    dita_content = DITAContent()
-    dita_content.begin_section("Alarms")
-
-    for alarm_file in alarms_files:
-        alarm_list = parse_alarms_file(alarm_file)
-
-        for alarm in alarm_list:
-            for alarm_level in alarm._levels.itervalues():
-                fields = {"OID": full_alarm_oid(alarm_level._oid),
-                          "ITU severity": alarm_level._itu_severity,
-                          "Severity": alarm_level._severity_string,
-                          "Description": alarm_level._description,
-                          "Details": alarm_level._details,
-                          "Cause": alarm_level._cause,
-                          "Effect": alarm_level._effect,
-                          "Action": alarm_level._action}
-
-                dita_content.begin_table(alarm._name + ": " + alarm_level._severity_string,
-                                         ["Field", "Value"],
-                                         ["25%", "75%"])
-                for field, value in fields.iteritems():
-                    dita_content.add_table_entry([field, value])
-                dita_content.end_table()
-
-    dita_content.end_section()
-    return dita_content._xml
-
-
-# Read in alarm information from a list of alarms files and write a DITA
-# document describing them.
-def write_dita_file(alarms_files, dita_filename): #pragma: no cover
-    xml = alarms_to_dita(alarms_files)
-
-    with open(dita_filename, "w") as dita_file:
-        dita_file.write(xml)
 
 
 # Read in alarm information from a list of alarms files and write a CSV

--- a/metaswitch/common/alarms_to_dita.py
+++ b/metaswitch/common/alarms_to_dita.py
@@ -34,7 +34,48 @@
 
 import argparse
 import os
-from alarms_parser import write_dita_file
+from alarms_parser import parse_alarms_file, full_alarm_oid
+from dita_content import DITAContent
+
+# Read in alarm information from a list of alarms files and generate a DITA
+# document describing the alarms.   Returns DITA as XML.
+def alarms_to_dita(alarms_files):
+    dita_content = DITAContent()
+    dita_content.begin_section("Alarms")
+
+    for alarm_file in alarms_files:
+        alarm_list = parse_alarms_file(alarm_file)
+
+        for alarm in alarm_list:
+            for alarm_level in alarm._levels.itervalues():
+                fields = {"OID": full_alarm_oid(alarm_level._oid),
+                          "ITU severity": alarm_level._itu_severity,
+                          "Severity": alarm_level._severity_string,
+                          "Description": alarm_level._description,
+                          "Details": alarm_level._details,
+                          "Cause": alarm_level._cause,
+                          "Effect": alarm_level._effect,
+                          "Action": alarm_level._action}
+
+                dita_content.begin_table(alarm._name + ": " + alarm_level._severity_string,
+                                         ["Field", "Value"],
+                                         ["25%", "75%"])
+                for field, value in fields.iteritems():
+                    dita_content.add_table_entry([field, value])
+                dita_content.end_table()
+
+    dita_content.end_section()
+    return dita_content._xml
+
+
+# Read in alarm information from a list of alarms files and write a DITA
+# document describing them.
+def write_dita_file(alarms_files, dita_filename): #pragma: no cover
+    xml = alarms_to_dita(alarms_files)
+
+    with open(dita_filename, "w") as dita_file:
+        dita_file.write(xml)
+
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--alarms-files', nargs="*", type=str, required=True)
@@ -44,3 +85,5 @@ args = parser.parse_args()
 dita_filename = os.path.join('.', args.output_dir, 'alarms.xml')
 
 write_dita_file(args.alarms_files, dita_filename)
+
+

--- a/metaswitch/common/test/alarms_parser.py
+++ b/metaswitch/common/test/alarms_parser.py
@@ -32,7 +32,8 @@
 
 import unittest
 from metaswitch.common.alarms import CLEARED, CRITICAL
-from metaswitch.common.alarms_parser import parse_alarms_file, render_alarm, alarms_to_dita, alarms_to_csv
+from metaswitch.common.alarms_parser import parse_alarms_file, render_alarm, alarms_to_csv
+from metaswitch.common.alarms_to_dita import alarms_to_dita
 
 class AlarmsParserTestCase(unittest.TestCase):
     def testValidFile(self):


### PR DESCRIPTION
As preparation to move `alarms_to_csv`, `alarms_to_dita`, `stats_to_dita` and `generate_stats_csv` to a dedicated docs-tools repository I have removed the dependency on `dita_content` from `alarms_parser` so that `dita_content` can be moved to the docs-tools repository as well.
I ran `make verify` which succeeded and also made sure the change `test/alarms_parser.py` to reflect the new layout.