### PR TITLE
Pin python dependencies in python-common

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,11 +55,15 @@ setup(
     cffi_modules=["cffi_build.py:ffi"],
     install_requires=[
         "cffi==1.10.0",
-        "funcsigs==1.0.2",
         "monotonic==0.6",
         "py-bcrypt==0.4",
         "pycparser==2.17",
         "pycrypto==2.6.1",
         "pyzmq==16.0.2"],
-    tests_require=["pbr==1.6", "Mock", "phonenumbers==7.1.1"]
+    tests_require=[
+        "funcsigs==1.0.2",
+        "Mock==2.0.0",
+        "pbr==1.6",
+        "phonenumbers==7.1.1",
+        "six==1.10.0"]
     )

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,13 @@ setup(
     setup_requires=["cffi"],
     ext_package="metaswitch.common",
     cffi_modules=["cffi_build.py:ffi"],
-    install_requires=["py-bcrypt==0.4", "pycrypto==2.6.1", "pyzmq==16.0.2",
-        "cffi==1.5.2", "monotonic==0.6", "pycparser==2.17"],
+    install_requires=[
+        "cffi==1.10.0",
+        "funcsigs==1.0.2",
+        "monotonic==0.6",
+        "py-bcrypt==0.4",
+        "pycparser==2.17",
+        "pycrypto==2.6.1",
+        "pyzmq==16.0.2"],
     tests_require=["pbr==1.6", "Mock", "phonenumbers==7.1.1"]
     )

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ setup(
     setup_requires=["cffi"],
     ext_package="metaswitch.common",
     cffi_modules=["cffi_build.py:ffi"],
-    install_requires=["py-bcrypt==0.4", "pycrypto==2.6.1", "pyzmq==16.0.2", "cffi==1.5.2", "monotonic==0.6"],
+    install_requires=["py-bcrypt==0.4", "pycrypto==2.6.1", "pyzmq==16.0.2",
+        "cffi==1.5.2", "monotonic==0.6", "pycparser==2.17"],
     tests_require=["pbr==1.6", "Mock", "phonenumbers==7.1.1"]
     )

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,6 @@ setup(
     setup_requires=["cffi"],
     ext_package="metaswitch.common",
     cffi_modules=["cffi_build.py:ffi"],
-    install_requires=["py-bcrypt", "pycrypto==2.6.1", "pyzmq==16.0.2", "cffi==1.5.2", "monotonic==0.6"],
+    install_requires=["py-bcrypt==0.4", "pycrypto==2.6.1", "pyzmq==16.0.2", "cffi==1.5.2", "monotonic==0.6"],
     tests_require=["pbr==1.6", "Mock", "phonenumbers==7.1.1"]
     )


### PR DESCRIPTION
I pinned all the python packages to the versions found in the build logs (for the last successful build).

The exception is cffi, which I pinned to a more up-to-date version to allow Crest to build again.

I also added downstream dependencies in.
I found these by using the console output from the build server, and also by seeing what packages were present in the .eggs directory created when the repo is made.

I've spun up a deployment including these changes using chef, and it build correctly.