### PR TITLE
[Reviewer: HJS] Reserve some PDLog ID ranges

### DIFF
--- a/metaswitch/common/pdlogs.py
+++ b/metaswitch/common/pdlogs.py
@@ -33,6 +33,9 @@ class PDLog(object):
     # Range 17000 to 17999 is reserved
     # Range 18000 to 18999 is reserved
     # Range 19000 to 19999 is reserved
+    # Range 20000 to 20999 is reserved
+    # Range 21000 to 21999 is reserved
+    # Range 22000 to 22999 is reserved
 
     def __init__(self, number, desc, cause, effect, action, priority):
         """Defines a particular log's priority and log text.


### PR DESCRIPTION
Marks these ID ranges as reserved so that nobody else will use them.