### PR TITLE
[Reviewer: Chris] Fix python packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,9 +9,9 @@ build
 bin
 bootstrap.py
 develop-eggs
-eggs
 htmlcov
 .eggs
+.wheelhouse
 *.a
 *.o
 *.so

--- a/Makefile
+++ b/Makefile
@@ -58,15 +58,17 @@ $(ENV_DIR)/bin/python:
 $(ENV_DIR)/bin/coverage: $(ENV_DIR)/bin/python
 	$(ENV_DIR)/bin/pip install coverage
 
+# Target for building a wheel from this package into the specified wheelhouse
 .PHONY: build_common_wheel
 build_common_wheel: $(ENV_DIR)/bin/python setup.py libclearwaterutils.a
-	$(COMPILER_FLAGS) ${ENV_DIR}/bin/pip wheel -w ${WHEELHOUSE} -r requirements.txt .
+	$(COMPILER_FLAGS) ${ENV_DIR}/bin/python setup.py bdist_wheel -d ${WHEELHOUSE}
 
+# Install this package, and it's dependencies into the environment
 ${ENV_DIR}/.wheels_installed : $(ENV_DIR)/bin/python setup.py requirements.txt $(shell find metaswitch -type f -not -name "*.pyc") libclearwaterutils.a
 	rm -rf .wheelhouse
 
 	# Generate .whl files for python-common and dependencies
-	$(COMPILER_FLAGS) ${ENV_DIR}/bin/pip wheel -w .wheelhouse -r requirements.txt .
+	$(COMPILER_FLAGS) ${ENV_DIR}/bin/pip wheel -w .wheelhouse -r requirements.txt -r requirements-test.txt .
 
 	# Install the downloaded wheels
 	${ENV_DIR}/bin/pip install --compile \

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,5 @@
+funcsigs==1.0.2
+Mock==2.0.0
+pbr==1.6
+phonenumbers==7.1.1
+six==1.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,11 +2,4 @@ cffi==1.10.0
 monotonic==0.6
 pycparser==2.18
 pycrypto==2.6.1
-pyzmq==16.0.2,
-
-# Test dependencies
-funcsigs==1.0.2
-Mock==2.0.0
-pbr==1.6
-phonenumbers==7.1.1
-six==1.10.0
+pyzmq==16.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,12 @@
+cffi==1.10.0
+monotonic==0.6
+pycparser==2.18
+pycrypto==2.6.1
+pyzmq==16.0.2,
+
+# Test dependencies
+funcsigs==1.0.2
+Mock==2.0.0
+pbr==1.6
+phonenumbers==7.1.1
+six==1.10.0

--- a/setup.py
+++ b/setup.py
@@ -29,15 +29,15 @@ setup(
     ext_package="metaswitch.common",
     cffi_modules=["cffi_build.py:ffi"],
     install_requires=[
-        "cffi==1.10.0",
-        "monotonic==0.6",
-        "pycparser==2.18",
-        "pycrypto==2.6.1",
-        "pyzmq==16.0.2"],
+        "cffi",
+        "monotonic",
+        "pycparser",
+        "pycrypto",
+        "pyzmq"],
     tests_require=[
-        "funcsigs==1.0.2",
-        "Mock==2.0.0",
-        "pbr==1.6",
-        "phonenumbers==7.1.1",
-        "six==1.10.0"]
+        "funcsigs",
+        "Mock",
+        "pbr",
+        "phonenumbers",
+        "six"]
     )


### PR DESCRIPTION
- Use wheels instead of eggs
- Use requirements.txt to track dependencies instead of setup.py