### PR TITLE
[No reviewer] Enforce a later version of pip

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,9 @@ build_common_wheel: $(PYTHON) setup.py libclearwaterutils.a
 ${ENV_DIR}/.wheels_installed : $(ENV_DIR)/bin/python setup.py requirements.txt $(shell find metaswitch -type f -not -name "*.pyc") libclearwaterutils.a
 	rm -rf .wheelhouse
 
+	# Enforce a recent version of pip is installed
+	${PIP} install --upgrade pip==7.0.1
+
 	# Check that pip wheel is installed
 	${PIP} install wheel
 


### PR DESCRIPTION
If Python gives us an old version of pip in the environment, it fails with the following, so enforce a newer version:

```
Running setup.py bdist_wheel for metaswitchcommon 
  Destination directory: /home/user/src/python-common/.wheelhouse 
Successfully built cffi monotonic pycparser pycrypto pyzmq metaswitchcommon 
Cleaning up... 
# Install the downloaded wheels 
/home/user/src/python-common/_env/bin/pip install --compile --no-index --upgrade --pre --force-reinstall --find-links=.wheelhouse metaswitchcommon 
Ignoring indexes: https://pypi.python.org/simple/ 
Downloading/unpacking metaswitchcommon 
  Could not find any downloads that satisfy the requirement metaswitchcommon 
Cleaning up... 
No distributions at all found for metaswitchcommon
```