### PR TITLE
[Reviewer: Seb] Pin and require versions of pip and wheel

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ monotonic==0.6
 pycparser==2.18
 pycrypto==2.6.1
 pyzmq==16.0.2
+pip==9.0.1
+wheel==0.30.0


### PR DESCRIPTION
We need to install later versions of pip and wheel in order to be able to install the rest of the wheels (particularly ones with embedded C - e.g. cffi).

This pins updated versions of the wheels. There's co-requisite changes to install these in each rep which uses python-common sadly.