### PR TITLE
[No reviewer] Use UTC for python logfile names

### DIFF
--- a/metaswitch/common/logging_config.py
+++ b/metaswitch/common/logging_config.py
@@ -44,7 +44,7 @@ class ClearwaterLogHandler(BaseRotatingHandler):
         if tmpstream:
             tmpstream.close() #pragma: no cover
         currentTime = int(time.time())
-        self.baseFilename = getCurrentFilename(datetime.fromtimestamp(currentTime),
+        self.baseFilename = getCurrentFilename(datetime.utcfromtimestamp(currentTime),
                                                self._log_directory,
                                                self._logfile_prefix)
         self.stream = os.fdopen(os.open(self.baseFilename, os.O_WRONLY | os.O_CREAT, 0644), self.mode)


### PR DESCRIPTION
Simple change of `datetime.fromtimestamp` to `datetime.utcfromtimestamp`

Tested live on a system running in a different timezone (CEST), and the queue-manager_<timestamp> log had the correct UTC time in it. This matches changes in https://github.com/Metaswitch/clearwater-etcd/pull/499 so we are more consistent