### PR TITLE
[Reviewer: Richard] Common python build infra

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 .installed.cfg
 _env
 build
+build_setup
 bin
 bootstrap.py
 develop-eggs

--- a/.gitignore
+++ b/.gitignore
@@ -11,8 +11,10 @@ bin
 bootstrap.py
 develop-eggs
 htmlcov
+coverage.xml
 .eggs
 .wheelhouse
+python_common_wheelhouse
 *.a
 *.o
 *.so

--- a/Makefile
+++ b/Makefile
@@ -31,18 +31,10 @@ python_common_WHEELS = metaswitchcommon
 python_common_SOURCES = $(shell find metaswitch -type f -not -name "*.pyc") libclearwaterutils.a
 $(eval $(call python_component,python_common))
 
-.PHONY: test
-test: install-wheels
-	$(COMPILER_FLAGS) $(ENV_DIR)/bin/python setup.py test
-
-
 # Target for building a wheel from this package into the specified wheelhouse
 .PHONY: build_common_wheel
 build_common_wheel: ${PIP} setup.py libclearwaterutils.a
 	$(COMPILER_FLAGS) ${PYTHON} setup.py bdist_wheel -d ${WHEELHOUSE}
-
-.PHONY: env
-env: ${ENV_DIR}/.wheels-installed
 
 VPATH = cpp-common/src:cpp-common/include
 

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,6 @@ CLEAN_SRC_DIR = .
 
 # We have not written UTs for a number of modules that do not justify it.   Exclude them from coverage results.
 COVERAGE_EXCL = **/test/**,metaswitch/common/alarms_writer.py,metaswitch/common/alarms_to_dita.py,metaswitch/common/alarms_to_csv.py,metaswitch/common/stats_to_dita.py,metaswitch/common/generate_stats_csv.py,metaswitch/common/mib.py
-COVERAGE_SETUP_PY = setup.py
 COVERAGE_SRC_DIR = metaswitch
 FLAKE8_INCLUDE_DIR = metaswitch/
 BANDIT_EXCLUDE_LIST = metaswitch/common/test,build,_env,.wheelhouse

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ ENV_DIR := $(shell pwd)/_env
 PYTHON_BIN := $(shell which python)
 
 COMPILER_FLAGS := LIBRARY_PATH=. CC="${CC} -Icpp-common/include"
-SRC_DIR = .
+CLEAN_SRC_DIR = .
 
 # We have not written UTs for a number of modules that do not justify it.   Exclude them from coverage results.
 COVERAGE_EXCL = **/test/**,metaswitch/common/alarms_writer.py,metaswitch/common/alarms_to_dita.py,metaswitch/common/alarms_to_csv.py,metaswitch/common/stats_to_dita.py,metaswitch/common/generate_stats_csv.py,metaswitch/common/mib.py

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ python_common_REQUIREMENTS = requirements.txt requirements-test.txt
 python_common_FLAGS = LIBRARY_PATH=. CC="${CC} -Icpp-common/include"
 python_common_WHEELS = metaswitchcommon
 python_common_SOURCES = $(shell find metaswitch -type f -not -name "*.pyc") libclearwaterutils.a
-$(eval $(call test_python_component,python_common))
+$(eval $(call python_component,python_common))
 
 .PHONY: test
 test: install-wheels
@@ -42,16 +42,16 @@ coverage: $(ENV_DIR)/bin/coverage setup.py env
 	_env/bin/coverage report -m --fail-under 100
 	_env/bin/coverage html
 
+# Target for building a wheel from this package into the specified wheelhouse
+.PHONY: build_common_wheel
+build_common_wheel: ${PIP} setup.py libclearwaterutils.a
+	$(COMPILER_FLAGS) ${PYTHON} setup.py bdist_wheel -d ${WHEELHOUSE}
+
 .PHONY: env
-env: ${ENV_DIR}/.wheels_installed
+env: ${ENV_DIR}/.wheels-installed
 
 $(ENV_DIR)/bin/coverage: $(ENV_DIR)/bin/python
 	$(ENV_DIR)/bin/pip install coverage
-
-
-# TODO
-#
-#	$(PIP) install cffi
 
 .PHONY: clean
 clean: envclean pyclean


### PR DESCRIPTION
Changes to use: https://github.com/Metaswitch/clearwater-build-infra/pull/69

We still need a separate `build_common_wheel` target as that's used by etcd (and anything else that uses python-common).

Other than that, it's a fairly straightforward usage of the new common infra.