### PR TITLE
Fix bandit medium issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ CLEAN_SRC_DIR = .
 COVERAGE_EXCL = **/test/**,metaswitch/common/alarms_writer.py,metaswitch/common/alarms_to_dita.py,metaswitch/common/alarms_to_csv.py,metaswitch/common/stats_to_dita.py,metaswitch/common/generate_stats_csv.py,metaswitch/common/mib.py
 COVERAGE_SRC_DIR = metaswitch
 FLAKE8_INCLUDE_DIR = metaswitch/
-BANDIT_EXCLUDE_LIST = metaswitch/common/test,build,_env,.wheelhouse
+BANDIT_EXCLUDE_LIST = metaswitch/common/test,build,_env,eggs,.wheelhouse
 include build-infra/python.mk
 
 # The build has been seen to fail on Mac OSX when trying to build on i386. Enable this to build for x86_64 only

--- a/metaswitch/common/utils.py
+++ b/metaswitch/common/utils.py
@@ -153,8 +153,10 @@ def delete_if_exists(fn): # pragma: no cover
     except OSError:
         pass
 
+# SIP digest authentication uses md5 instead of more secure hash algorithms.
+# Leave out this function from Bandit security analysis.
 def md5(s): # pragma: no cover
-    digest = hashlib.md5()
+    digest = hashlib.md5() # nosec
     digest.update(s)
     return digest.hexdigest()
 


### PR DESCRIPTION
Leave out MD5 from bandit analysis as it's required by SIP spec.
  
  